### PR TITLE
Fix: Prevent Locale class redeclaration by ensuring config is loaded …

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -88,4 +88,5 @@ Locale::initialize(DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, APP_ROOT . '/locale');
 // If you define SITE_NAME_KEY, ensure the corresponding key exists in your language files.
 // define('SITE_NAME_KEY', 'site_name_default'); // e.g., 'site_name_default' => "Paragliding Booking System" in en/messages.php
 
+define('CONFIG_LOADED', true);
 ?>

--- a/paragliding_booking/templates/layouts/header.php
+++ b/paragliding_booking/templates/layouts/header.php
@@ -1,14 +1,23 @@
 <?php
 // ... (existing header PHP code from previous step) ...
 if (session_status() == PHP_SESSION_NONE && php_sapi_name() !== 'cli') { session_start(); }
-if (!defined('BASE_URL') || !class_exists('Locale')) {
+
+// Check if the config file has already been loaded.
+// This prevents redefining constants and re-declaring classes if header.php is included
+// by a script that has already loaded config.php.
+if (!defined('CONFIG_LOADED')) {
     $config_path = dirname(__DIR__, 2) . '/config/config.php';
-    if(file_exists($config_path)) {
+    if (file_exists($config_path)) {
         require_once $config_path;
     } else {
-        die("Config file not found for header template.");
+        // If config.php is essential and not found, terminate.
+        // This is a fallback for cases where header.php might be included standalone
+        // or by a script that doesn't load config.php first.
+        die("Critical configuration file not found. Ensure config.php is loaded before this header.");
     }
 }
+
+// Proceed with header setup, assuming config (and Locale class) is now available.
 $page_title_key = defined('PAGE_TITLE_KEY') ? PAGE_TITLE_KEY : 'page_title_default';
 $page_title_params = defined('PAGE_TITLE_PARAMS') ? PAGE_TITLE_PARAMS : [];
 $current_lang = Locale::getLanguage();


### PR DESCRIPTION
…only once

The error "Cannot declare class Locale, because the name is already in use" was occurring because `config.php` (which includes `src/Locale.php`) was being loaded multiple times during a single request, particularly when `templates/layouts/header.php` was included by a script that had already loaded the configuration.

This commit introduces a `CONFIG_LOADED` constant in `config.php` and modifies `header.php` to check for this constant before attempting to load `config.php` again. This ensures that the configuration and the Locale class are only loaded once per request lifecycle.